### PR TITLE
Decrease lowest resolution limitation in driver

### DIFF
--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -3366,7 +3366,7 @@ Bool drmmode_pre_init(ScrnInfoPtr pScrn, drmmode_ptr drmmode, int cpp)
 		return FALSE;
 
 	drmmode->count_crtcs = mode_res->count_crtcs;
-	xf86CrtcSetSizeRange(pScrn, 320, 200, mode_res->max_width,
+	xf86CrtcSetSizeRange(pScrn, 100, 100, mode_res->max_width,
 			     mode_res->max_height);
 
 	xf86DrvMsgVerb(pScrn->scrnIndex, X_INFO, AMDGPU_LOGLEVEL_DEBUG,


### PR DESCRIPTION
This will fix the lowest resolution limitation in the driver triggered by SDL2 2.0.16